### PR TITLE
3.2.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 ### Model Build Safety Guard
 
 - Added a pre-build guard for non-MLPT model builds that checks Autoslew pointing corrections (`GetCorrections`).
-- If corrections are non-zero (indicating config/model was not cleared), the user is prompted with a Yes/No confirmation before continuing.
-- Proceeding explicitly warns that the new model will be built on top of an existing model (potentially useful for PA/collimation with few points, but not recommended for full-sky models).
+  - If corrections are non-zero (indicating config/model was not cleared), the user is prompted with a Yes/No confirmation before continuing.
+  - Proceeding explicitly warns that the new model will be built on top of an existing model (potentially useful for PA/collimation with few points, but not recommended for full-sky models).
 
 ## 3.2.8.3 (2026-02-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 
 # Changelog
 
+## 3.8.2.5 (2026-02-22)
+
+### AutoGrid Anchoring
+
+- Added **Start at horizon** as a shared option (global + builder) for AutoGrid.
+- Added **End at meridian limit** as a shared option (global + builder) for AutoGrid.
+- Made both anchor modes mutually exclusive so enabling one automatically disables the other.
+- Improved AutoGrid anchoring logic to evaluate each side (east/west) per band independently.
+- Enabled **End at meridian limit** behavior for both AutoGrid input modes:
+  - **Desired points** mode
+  - **Fixed spacing** mode
+- Added a fixed **1° safety margin** from the meridian limit target to reduce unexpected flip-risk edge cases.
+
+### Options UI / Usability
+
+- Reorganized plugin options into clearer categories in the main options template.
+- Added/updated descriptions and tooltips for ambiguous settings (including Legacy DDM and dome-control options).
+- Moved **Show path** into **Chart options** in the model builder UI.
+- Moved **Min horizon distance** into **AutoGrid options** in the model builder UI.
+
 ## 3.2.8.4
 
 ### Model Build Safety Guard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 
 # Changelog
 
+## 3.2.8.4
+
+### Model Build Safety Guard
+
+- Added a pre-build guard for non-MLPT model builds that checks Autoslew pointing corrections (`GetCorrections`).
+- If corrections are non-zero (indicating config/model was not cleared), the user is prompted with a Yes/No confirmation before continuing.
+- Proceeding explicitly warns that the new model will be built on top of an existing model (potentially useful for PA/collimation with few points, but not recommended for full-sky models).
+
 ## 3.2.8.3 (2026-02-20)
 
 ### AutoGrid / Band Path Simplification
@@ -16,6 +24,8 @@
 - Changed default model builder generator from **Golden Spiral** to **AutoGrid**.
 - Changed default AutoGrid path ordering mode from **Legacy Azimuth Sweep** to **ASA Band Path**.
 - Changed default AutoGrid desired-point count from **195** to **50**.
+
+
 
 ## 3.2.8.2 (2026-02-18)
 

--- a/NINA.Photon.Plugin.ASA/ASAOptions.cs
+++ b/NINA.Photon.Plugin.ASA/ASAOptions.cs
@@ -50,6 +50,7 @@ namespace NINA.Photon.Plugin.ASA
             autoGridInputMode = optionsAccessor.GetValueEnum("AutoGridInputMode", AutoGridInputModeEnum.Spacing);
             autoGridPathOrderingMode = optionsAccessor.GetValueEnum("AutoGridPathOrderingMode", AutoGridPathOrderingModeEnum.ASABandPath);
             autoGridDesiredPointCount = optionsAccessor.GetValueInt32("AutoGridDesiredPointCount", 50);
+            startAtHorizon = optionsAccessor.GetValueBoolean("StartAtHorizon", false);
             siderealTrackStartOffsetMinutes = optionsAccessor.GetValueInt32("SiderealTrackStartOffsetMinutes", 0);
             siderealTrackEndOffsetMinutes = optionsAccessor.GetValueInt32("SiderealTrackEndOffsetMinutes", 0);
             siderealTrackPathOffsetMinutes = optionsAccessor.GetValueInt32("SiderealTrackPathOffsetMinutes", 0);
@@ -116,6 +117,7 @@ namespace NINA.Photon.Plugin.ASA
             AutoGridInputMode = AutoGridInputModeEnum.Spacing;
             AutoGridPathOrderingMode = AutoGridPathOrderingModeEnum.ASABandPath;
             AutoGridDesiredPointCount = 50;
+            StartAtHorizon = false;
             SiderealTrackStartOffsetMinutes = 0;
             SiderealTrackEndOffsetMinutes = 0;
             SiderealTrackPathOffsetMinutes = 0;
@@ -333,6 +335,22 @@ namespace NINA.Photon.Plugin.ASA
 
                     autoGridDesiredPointCount = value;
                     optionsAccessor.SetValueInt32("AutoGridDesiredPointCount", autoGridDesiredPointCount);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool startAtHorizon;
+
+        public bool StartAtHorizon
+        {
+            get => startAtHorizon;
+            set
+            {
+                if (startAtHorizon != value)
+                {
+                    startAtHorizon = value;
+                    optionsAccessor.SetValueBoolean("StartAtHorizon", startAtHorizon);
                     RaisePropertyChanged();
                 }
             }

--- a/NINA.Photon.Plugin.ASA/ASAOptions.cs
+++ b/NINA.Photon.Plugin.ASA/ASAOptions.cs
@@ -51,6 +51,7 @@ namespace NINA.Photon.Plugin.ASA
             autoGridPathOrderingMode = optionsAccessor.GetValueEnum("AutoGridPathOrderingMode", AutoGridPathOrderingModeEnum.ASABandPath);
             autoGridDesiredPointCount = optionsAccessor.GetValueInt32("AutoGridDesiredPointCount", 50);
             startAtHorizon = optionsAccessor.GetValueBoolean("StartAtHorizon", false);
+            balanceMeridianZone = optionsAccessor.GetValueBoolean("BalanceMeridianZone", false);
             siderealTrackStartOffsetMinutes = optionsAccessor.GetValueInt32("SiderealTrackStartOffsetMinutes", 0);
             siderealTrackEndOffsetMinutes = optionsAccessor.GetValueInt32("SiderealTrackEndOffsetMinutes", 0);
             siderealTrackPathOffsetMinutes = optionsAccessor.GetValueInt32("SiderealTrackPathOffsetMinutes", 0);
@@ -118,6 +119,7 @@ namespace NINA.Photon.Plugin.ASA
             AutoGridPathOrderingMode = AutoGridPathOrderingModeEnum.ASABandPath;
             AutoGridDesiredPointCount = 50;
             StartAtHorizon = false;
+            BalanceMeridianZone = false;
             SiderealTrackStartOffsetMinutes = 0;
             SiderealTrackEndOffsetMinutes = 0;
             SiderealTrackPathOffsetMinutes = 0;
@@ -351,6 +353,38 @@ namespace NINA.Photon.Plugin.ASA
                 {
                     startAtHorizon = value;
                     optionsAccessor.SetValueBoolean("StartAtHorizon", startAtHorizon);
+
+                    if (startAtHorizon && balanceMeridianZone)
+                    {
+                        balanceMeridianZone = false;
+                        optionsAccessor.SetValueBoolean("BalanceMeridianZone", balanceMeridianZone);
+                        RaisePropertyChanged(nameof(BalanceMeridianZone));
+                    }
+
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool balanceMeridianZone;
+
+        public bool BalanceMeridianZone
+        {
+            get => balanceMeridianZone;
+            set
+            {
+                if (balanceMeridianZone != value)
+                {
+                    balanceMeridianZone = value;
+                    optionsAccessor.SetValueBoolean("BalanceMeridianZone", balanceMeridianZone);
+
+                    if (balanceMeridianZone && startAtHorizon)
+                    {
+                        startAtHorizon = false;
+                        optionsAccessor.SetValueBoolean("StartAtHorizon", startAtHorizon);
+                        RaisePropertyChanged(nameof(StartAtHorizon));
+                    }
+
                     RaisePropertyChanged();
                 }
             }

--- a/NINA.Photon.Plugin.ASA/Equipment/Mount.cs
+++ b/NINA.Photon.Plugin.ASA/Equipment/Mount.cs
@@ -204,6 +204,26 @@ namespace NINA.Photon.Plugin.ASA.Equipment
             return new Response<double>(0, rc);
         }
 
+        public Response<(double X, double Y)> GetCorrections()
+        {
+            string rc = this.mountCommander.SendCommandString("GetCorrections", true);
+            // Returns pointing corrections in radians: x.xxxxxxx#y.yyyyyyy (sign can be + or -)
+            var normalizedResponse = (rc ?? string.Empty).Trim().TrimEnd('#').Replace(',', '.');
+            var parts = normalizedResponse.Split('#');
+
+            if (
+                parts.Length >= 2
+                && double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var xCorrection)
+                && double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var yCorrection)
+            )
+            {
+                return new Response<(double X, double Y)>((xCorrection, yCorrection), rc);
+            }
+
+     
+            return new Response<(double X, double Y)>((0, 0), rc);
+        }
+
         public Response<double> TimeToLimit()
         {
             string rc = "0";

--- a/NINA.Photon.Plugin.ASA/Interfaces/IASAOptions.cs
+++ b/NINA.Photon.Plugin.ASA/Interfaces/IASAOptions.cs
@@ -45,6 +45,8 @@ namespace NINA.Photon.Plugin.ASA.Interfaces
 
         int AutoGridDesiredPointCount { get; set; }
 
+        bool StartAtHorizon { get; set; }
+
         string SiderealTrackStartTimeProvider { get; set; }
 
         string SiderealTrackEndTimeProvider { get; set; }

--- a/NINA.Photon.Plugin.ASA/Interfaces/IASAOptions.cs
+++ b/NINA.Photon.Plugin.ASA/Interfaces/IASAOptions.cs
@@ -47,6 +47,8 @@ namespace NINA.Photon.Plugin.ASA.Interfaces
 
         bool StartAtHorizon { get; set; }
 
+        bool BalanceMeridianZone { get; set; }
+
         string SiderealTrackStartTimeProvider { get; set; }
 
         string SiderealTrackEndTimeProvider { get; set; }

--- a/NINA.Photon.Plugin.ASA/Interfaces/IMount.cs
+++ b/NINA.Photon.Plugin.ASA/Interfaces/IMount.cs
@@ -105,6 +105,8 @@ namespace NINA.Photon.Plugin.ASA.Interfaces
 
         Response<double> MLPTTimeLeft();
 
+        Response<(double X, double Y)> GetCorrections();
+
         Response<double> TimeToLimit();
 
         Response<bool> GetDualAxisTrackingEnabled();

--- a/NINA.Photon.Plugin.ASA/ModelManagement/ModelBuilder.cs
+++ b/NINA.Photon.Plugin.ASA/ModelManagement/ModelBuilder.cs
@@ -247,23 +247,19 @@ namespace NINA.Photon.Plugin.ASA.ModelManagement
                     var corrections = mount.GetCorrections();
                     if (corrections.Value.X != 0 || corrections.Value.Y != 0)
                     {
-                        if (OperatingSystem.IsWindows())
-                        {
-                            var result = MessageBox.Show(
-                                "Config was not cleared in Autoslew. Proceed?",
-                                "ASA Model Builder",
-                                MessageBoxButtons.YesNo,
-                                MessageBoxIcon.Warning);
+                        var result = System.Windows.MessageBox.Show(
+                            "Config was not cleared in Autoslew.\n\nProceeding will build a new model on top of an existing model.\n\nThis can be useful for PA/collimation with only a few points, but it is NOT recommended for a full-sky model.",
+                            "ASA Model Builder",
+                            System.Windows.MessageBoxButton.YesNo,
+                            System.Windows.MessageBoxImage.Warning);
 
-                            if (result != DialogResult.Yes)
-                            {
-                                throw new OperationCanceledException("Model build canceled because Autoslew config was not cleared");
-                            }
-                        }
-                        else
+                        if (result != System.Windows.MessageBoxResult.Yes)
                         {
-                            Logger.Warning("Config was not cleared in Autoslew, but interactive confirmation is only supported on Windows. Proceeding by default");
+                            throw new OperationCanceledException("Model build canceled because Autoslew config was not cleared");
                         }
+
+                        Logger.Warning("Proceeding with build while Autoslew config was not cleared. A model will be built on top of an existing model; this is only typically useful for PA/collimation with few points, not full-sky models");
+                        Notification.ShowWarning("Proceeding with uncleared Autoslew config: building model on top of existing model. Use only for PA/collimation with few points, not full-sky models");
                     }
                 }
             }

--- a/NINA.Photon.Plugin.ASA/ModelManagement/ModelBuilder.cs
+++ b/NINA.Photon.Plugin.ASA/ModelManagement/ModelBuilder.cs
@@ -239,6 +239,35 @@ namespace NINA.Photon.Plugin.ASA.ModelManagement
             PreFlightChecks(modelPoints);
             forceNextPierSideAvailable = true;
 
+            if (options != null)
+            {
+                
+                if ( options.ModelPointGenerationType != ModelPointGenerationTypeEnum.SiderealPath)
+                {
+                    var corrections = mount.GetCorrections();
+                    if (corrections.Value.X != 0 || corrections.Value.Y != 0)
+                    {
+                        if (OperatingSystem.IsWindows())
+                        {
+                            var result = MessageBox.Show(
+                                "Config was not cleared in Autoslew. Proceed?",
+                                "ASA Model Builder",
+                                MessageBoxButtons.YesNo,
+                                MessageBoxIcon.Warning);
+
+                            if (result != DialogResult.Yes)
+                            {
+                                throw new OperationCanceledException("Model build canceled because Autoslew config was not cleared");
+                            }
+                        }
+                        else
+                        {
+                            Logger.Warning("Config was not cleared in Autoslew, but interactive confirmation is only supported on Windows. Proceeding by default");
+                        }
+                    }
+                }
+            }
+
             var innerCts = new CancellationTokenSource();
             var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, innerCts.Token);
             var telescopeInfo = telescopeMediator.GetInfo();

--- a/NINA.Photon.Plugin.ASA/ModelManagement/ModelPointGenerator.cs
+++ b/NINA.Photon.Plugin.ASA/ModelManagement/ModelPointGenerator.cs
@@ -233,9 +233,7 @@ namespace NINA.Photon.Plugin.ASA.ModelManagement
                         }
 
                         point.DesiredPierSide = sideConfiguration.side;
-                        point.AutoGridHourAngleDegrees = options.StartAtHorizon
-                            ? GetStartAtHorizonHourAngleSortKey(shiftedHourAngleDegrees, sideConfiguration.side)
-                            : shiftedHourAngleDegrees;
+                        point.AutoGridHourAngleDegrees = shiftedHourAngleDegrees;
 
                         if (point.ModelPointState != ModelPointStateEnum.Generated)
                         {

--- a/NINA.Photon.Plugin.ASA/Properties/AssemblyInfo.cs
+++ b/NINA.Photon.Plugin.ASA/Properties/AssemblyInfo.cs
@@ -20,8 +20,8 @@ using System.Runtime.InteropServices;
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new release build of a plugin
 
-[assembly: AssemblyVersion("3.2.8.3")]
-[assembly: AssemblyFileVersion("3.2.8.3")]
+[assembly: AssemblyVersion("3.2.8.4")]
+[assembly: AssemblyFileVersion("3.2.8.4")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("ASA Tools")]

--- a/NINA.Photon.Plugin.ASA/Properties/AssemblyInfo.cs
+++ b/NINA.Photon.Plugin.ASA/Properties/AssemblyInfo.cs
@@ -20,8 +20,8 @@ using System.Runtime.InteropServices;
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new release build of a plugin
 
-[assembly: AssemblyVersion("3.2.8.4")]
-[assembly: AssemblyFileVersion("3.2.8.4")]
+[assembly: AssemblyVersion("3.2.8.5")]
+[assembly: AssemblyFileVersion("3.2.8.5")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("ASA Tools")]

--- a/NINA.Photon.Plugin.ASA/Resources/OptionsDataTemplates.xaml
+++ b/NINA.Photon.Plugin.ASA/Resources/OptionsDataTemplates.xaml
@@ -70,6 +70,7 @@
                 <RowDefinition />
                 <RowDefinition />
                 <RowDefinition />
+                <RowDefinition />
             </Grid.RowDefinitions>
             <Grid.Resources>
                 <TextBlock x:Key="LogCommands_Tooltip" Text="If enabled, every ASA command sent and response received will be logged at INFO level in the NINA log" />
@@ -81,6 +82,7 @@
                 <TextBlock x:Key="MaxPointAzimuth_Tooltip" Text="The maximum azimuth allowed for point generation. This is helpful for providing clearance during the point where meridian flips occur" />
                 <TextBlock x:Key="MinDistanceToHorizon_Tooltip" Text="Minimum clearance above the custom horizon required for generated points" />
                 <TextBlock x:Key="StartAtHorizon_Tooltip" Text="When enabled for AutoGrid, the first generated point per side (east/west) in each band starts from the lowest valid horizon-adjacent point" />
+                <TextBlock x:Key="BalanceMeridianZone_Tooltip" Text="For AutoGrid, anchors each band so its last point per side is as close as possible to meridian limit" />
                 <TextBlock x:Key="ShowRemovedPoints_Tooltip" Text="Whether to show points that were rejected for being outside of the altitude bounds or below the defined horizon" />
                 <TextBlock x:Key="DomeShutterWidth_Tooltip" Text="The width of the dome shutter, in mm. If set, this is used to determine if the scope is pointing out of the shutter instead of the Threshold setting from Dome Options" />
                 <TextBlock x:Key="MinimizeDomeMovement_Tooltip" Text="If enabled, points will be ordered based on the calculated dome azimuth. The left boundary of the dome opening is used for E-&gt;W sorting, and the right boundary for W-&gt;E" />
@@ -292,6 +294,23 @@
                 VerticalAlignment="Center"
                 IsChecked="{Binding StartAtHorizon}"
                 ToolTip="{StaticResource StartAtHorizon_Tooltip}" />
+
+            <TextBlock
+                Grid.Row="21"
+                Grid.Column="0"
+                VerticalAlignment="Center"
+                Text="End at Meridian Limit"
+                ToolTip="{StaticResource BalanceMeridianZone_Tooltip}" />
+            <CheckBox
+                Grid.Row="21"
+                Grid.Column="1"
+                Grid.ColumnSpan="2"
+                MinWidth="80"
+                Margin="5,5,0,0"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                IsChecked="{Binding BalanceMeridianZone}"
+                ToolTip="{StaticResource BalanceMeridianZone_Tooltip}" />
 
             <TextBlock
                 Grid.Row="11"

--- a/NINA.Photon.Plugin.ASA/Resources/OptionsDataTemplates.xaml
+++ b/NINA.Photon.Plugin.ASA/Resources/OptionsDataTemplates.xaml
@@ -41,38 +41,8 @@
     <TextBlock x:Key="MaxPointRMS_Tooltip" Text="After a build iteration, any point with an RMS greater than this value will be treated as a failed point during a retry" />
     <TextBlock x:Key="PoxOutputDirectory_Tooltip" Text="The directory where the POX files will be saved. By default, the POX files are created in the folder where Autoslew expects them. Change this if you want more control, or if you are running Autoslew on a different computer." />
     <DataTemplate x:Key="ASA_ModelBuilder_Options">
-        <Grid d:DataContext="{d:DesignInstance local:ASAOptions, IsDesignTimeCreatable=False}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition />
-                <ColumnDefinition />
-                <ColumnDefinition />
-            </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <!--  Hidden until this works  -->
-                <RowDefinition Height="0" />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-            </Grid.RowDefinitions>
-            <Grid.Resources>
+        <StackPanel d:DataContext="{d:DesignInstance local:ASAOptions, IsDesignTimeCreatable=False}" Grid.IsSharedSizeScope="True">
+            <StackPanel.Resources>
                 <TextBlock x:Key="LogCommands_Tooltip" Text="If enabled, every ASA command sent and response received will be logged at INFO level in the NINA log" />
                 <TextBlock x:Key="MaxConcurrency_Tooltip" Text="The maximum number of plate solves that can run concurrently during a model build. This can be set to infinite if you have plenty of system memory or are using a fast plate solver such as ASTAP with blind solves disabled" />
                 <TextBlock x:Key="AllowBlindSolves_Tooltip" Text="Plate solving is done over a narrow search radius to ensure it is fast. This should generally work since you know where the telescope is pointed, but could fail if the pointing model is very far off (more than 30 degrees). This setting enables falling back to blind solves when they fail, at the expense of potentially much longer model build times" />
@@ -81,497 +51,283 @@
                 <TextBlock x:Key="MinPointAzimuth_Tooltip" Text="The minimum azimuth allowed for point generation. This is helpful for providing clearance during the point where meridian flips occur" />
                 <TextBlock x:Key="MaxPointAzimuth_Tooltip" Text="The maximum azimuth allowed for point generation. This is helpful for providing clearance during the point where meridian flips occur" />
                 <TextBlock x:Key="MinDistanceToHorizon_Tooltip" Text="Minimum clearance above the custom horizon required for generated points" />
-                <TextBlock x:Key="StartAtHorizon_Tooltip" Text="When enabled for AutoGrid, the first generated point per side (east/west) in each band starts from the lowest valid horizon-adjacent point" />
-                <TextBlock x:Key="BalanceMeridianZone_Tooltip" Text="For AutoGrid, anchors each band so its last point per side is as close as possible to meridian limit" />
-                <TextBlock x:Key="ShowRemovedPoints_Tooltip" Text="Whether to show points that were rejected for being outside of the altitude bounds or below the defined horizon" />
+                <TextBlock x:Key="StartAtHorizon_Tooltip" Text="For AutoGrid, starts each side of every band from the lowest valid horizon-adjacent point" />
+                <TextBlock x:Key="BalanceMeridianZone_Tooltip" Text="For AutoGrid, anchors each side of every band so the final point is as close as possible to the meridian limit with a 1° safety margin" />
+                <TextBlock x:Key="ShowRemovedPoints_Tooltip" Text="Whether to show points that were rejected for being outside of altitude bounds or below the defined horizon" />
                 <TextBlock x:Key="DomeShutterWidth_Tooltip" Text="The width of the dome shutter, in mm. If set, this is used to determine if the scope is pointing out of the shutter instead of the Threshold setting from Dome Options" />
-                <TextBlock x:Key="MinimizeDomeMovement_Tooltip" Text="If enabled, points will be ordered based on the calculated dome azimuth. The left boundary of the dome opening is used for E-&gt;W sorting, and the right boundary for W-&gt;E" />
-                <TextBlock x:Key="MinimizeMeridianFlips_Tooltip" Text="If enabled, points will not cross over to the other side of the meridian until there are no more remaining on the current one. If you use a dome, this comes at the expensive of a potentially big dome movement in the middle of the model build" />
-                <TextBlock x:Key="WestToEast_Tooltip" Text="By default, points will be process from east to west. Enabling this toggle reverses that order" />
-                <TextBlock x:Key="PlateSolveSubframePercentage_Tooltip" Text="What percentage of the full camera resolution to use when taking exposures for plate solving. This is an alternative to binning, which increases the pixel scale" />
-                <TextBlock x:Key="RemoveHighRMSPointsAfterBuild_Tooltip" Text="Removes points with RMS above a threshold from a newly built model" />
-                <TextBlock x:Key="AlternateDirectionsBetweenIterations_Tooltip" Text="Alternates sort directions between each build iteration. This helps minimize scope, and particularly dome, movements" />
-                <TextBlock x:Key="DisableRefractionCorrection_Tooltip" Text="Disables refraction correction for the duration of model build. It is turned back on afterwards if it was originally enabled." />
-                <TextBlock x:Key="WolBroadcastIP_Tooltip" Text="The IP address to use for broadcasting the WOL packet to power on the mount. This might not be needed based on your network setup, but try setting this if Power On from the Mount Info pane doesn't work." />
-                <TextBlock x:Key="DecJitterSigma_Tooltip" Text="When creating a MLTP path model, points are randomly jittered along the dec arc. This parameter controls how wide this can vary, with the maximum distance being 3 * sigma." />
-            </Grid.Resources>
-            <TextBlock
-                Grid.Row="0"
-                Grid.Column="0"
-                VerticalAlignment="Center"
-                Text="Log Commands"
-                ToolTip="{StaticResource LogCommands_Tooltip}" />
-            <CheckBox
-                Grid.Row="0"
-                Grid.Column="1"
-                MinWidth="80"
-                Margin="5,5,0,0"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Center"
-                IsChecked="{Binding LogCommands}"
-                ToolTip="{StaticResource LogCommands_Tooltip}" />
-            <TextBlock
-                Grid.Row="1"
-                Grid.Column="0"
-                VerticalAlignment="Center"
-                Text="Max Concurrency"
-                ToolTip="{StaticResource MaxConcurrency_Tooltip}" />
-            <ninactrl:UnitTextBox
-                Grid.Row="1"
-                Grid.Column="1"
-                MinWidth="80"
-                Margin="5,5,0,0"
-                HorizontalAlignment="Left"
-                ToolTip="{StaticResource MaxConcurrency_Tooltip}"
-                Unit="plate solves">
-                <Binding
-                    Converter="{StaticResource TM_ZeroToInfinityConverter}"
-                    Path="MaxConcurrency"
-                    UpdateSourceTrigger="LostFocus">
-                    <Binding.ValidationRules>
-                        <tmrules:PositiveIntegerOrInfiniteRule />
-                    </Binding.ValidationRules>
-                </Binding>
-            </ninactrl:UnitTextBox>
-            <TextBlock
-                Grid.Row="3"
-                Grid.Column="0"
-                VerticalAlignment="Center"
-                Text="Allow Blind Solves"
-                ToolTip="{StaticResource AllowBlindSolves_Tooltip}" />
-            <CheckBox
-                Grid.Row="3"
-                Grid.Column="1"
-                MinWidth="80"
-                Margin="5,5,0,0"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Center"
-                IsChecked="{Binding AllowBlindSolves}"
-                ToolTip="{StaticResource AllowBlindSolves_Tooltip}" />
-            <TextBlock
-                Grid.Row="4"
-                Grid.Column="0"
-                VerticalAlignment="Center"
-                Text="Min Altitude"
-                ToolTip="{StaticResource MinPointAltitude_Tooltip}" />
-            <ninactrl:UnitTextBox
-                Grid.Row="4"
-                Grid.Column="1"
-                MinWidth="80"
-                Margin="5,5,0,0"
-                HorizontalAlignment="Left"
-                ToolTip="{StaticResource MinPointAltitude_Tooltip}"
-                Unit="°">
-                <Binding Path="MinPointAltitude" UpdateSourceTrigger="LostFocus">
-                    <Binding.ValidationRules>
-                        <rules:IntRangeRule>
-                            <rules:IntRangeRule.ValidRange>
-                                <rules:IntRangeChecker Maximum="90" Minimum="0" />
-                            </rules:IntRangeRule.ValidRange>
-                        </rules:IntRangeRule>
-                    </Binding.ValidationRules>
-                </Binding>
-            </ninactrl:UnitTextBox>
-            <TextBlock
-                Grid.Row="5"
-                Grid.Column="0"
-                VerticalAlignment="Center"
-                Text="Max Altitude"
-                ToolTip="{StaticResource MaxPointAltitude_Tooltip}" />
-            <ninactrl:UnitTextBox
-                Grid.Row="5"
-                Grid.Column="1"
-                MinWidth="80"
-                Margin="5,5,0,0"
-                HorizontalAlignment="Left"
-                ToolTip="{StaticResource MaxPointAltitude_Tooltip}"
-                Unit="°">
-                <Binding Path="MaxPointAltitude" UpdateSourceTrigger="LostFocus">
-                    <Binding.ValidationRules>
-                        <rules:IntRangeRule>
-                            <rules:IntRangeRule.ValidRange>
-                                <rules:IntRangeChecker Maximum="90" Minimum="0" />
-                            </rules:IntRangeRule.ValidRange>
-                        </rules:IntRangeRule>
-                    </Binding.ValidationRules>
-                </Binding>
-            </ninactrl:UnitTextBox>
-            <TextBlock
-                Grid.Row="6"
-                Grid.Column="0"
-                VerticalAlignment="Center"
-                Text="Show Removed Points"
-                ToolTip="{StaticResource ShowRemovedPoints_Tooltip}" />
-            <CheckBox
-                Grid.Row="6"
-                Grid.Column="1"
-                MinWidth="80"
-                Margin="5,5,0,0"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Center"
-                IsChecked="{Binding ShowRemovedPoints}"
-                ToolTip="{StaticResource ShowRemovedPoints_Tooltip}" />
-            <TextBlock
-                Grid.Row="7"
-                Grid.Column="0"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Center"
-                Text="Optimize Dome"
-                ToolTip="{StaticResource MinimizeDomeMovement_Tooltip}" />
-            <CheckBox
-                Grid.Row="7"
-                Grid.Column="1"
-                MinWidth="80"
-                Margin="5,5,0,0"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Center"
-                IsChecked="{Binding MinimizeDomeMovementEnabled}"
-                ToolTip="{StaticResource MinimizeDomeMovement_Tooltip}" />
+                <TextBlock x:Key="MinimizeDomeMovement_Tooltip" Text="If enabled, points are ordered based on calculated dome azimuth to reduce dome travel" />
+                <TextBlock x:Key="MinimizeMeridianFlips_Tooltip" Text="If enabled, points stay on the current meridian side until exhausted, reducing side switches" />
+                <TextBlock x:Key="WestToEast_Tooltip" Text="By default points are processed east-to-west. Enable to reverse that order" />
+                <TextBlock x:Key="PlateSolveSubframePercentage_Tooltip" Text="What percentage of full camera resolution to use for plate-solve exposures" />
+                <TextBlock x:Key="AlternateDirectionsBetweenIterations_Tooltip" Text="Alternates sort direction between each retry iteration to reduce repeated slew paths" />
+                <TextBlock x:Key="LegacyDDM_Tooltip" Text="Enable compatibility behavior for older Autoslew versions (5.2.4.8)" />
+                <TextBlock x:Key="DomeControlNINA_Tooltip" Text="When enabled, NINA manages dome positioning during model operations instead of leaving control external" />
+                <TextBlock x:Key="MLTPPathOffset_Tooltip" Text="Offset, in RA-minutes, used to shift the MLTP path start point. Negative values start in RA-, positive values in RA+" />
+            </StackPanel.Resources>
 
-            <TextBlock
-                Grid.Row="8"
-                Grid.Column="0"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Center"
-                Text="Dome Shutter Width"
-                ToolTip="{StaticResource DomeShutterWidth_Tooltip}" />
-            <ninactrl:UnitTextBox
-                Grid.Row="8"
-                Grid.Column="1"
-                MinWidth="80"
-                Margin="5,5,0,0"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Center"
-                ToolTip="{StaticResource DomeShutterWidth_Tooltip}"
-                Unit="mm">
-                <Binding
-                    Converter="{StaticResource TM_ZeroToDisabledConverter}"
-                    Path="DomeShutterWidth_mm"
-                    UpdateSourceTrigger="LostFocus">
-                    <Binding.ValidationRules>
-                        <rules:GreaterZeroRule />
-                    </Binding.ValidationRules>
-                </Binding>
-            </ninactrl:UnitTextBox>
-            <TextBlock
-                Grid.Row="8"
-                Grid.Column="2"
-                Margin="5,5,0,0"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Center"
-                Text="TIP: Make this less than the actual shutter width to give extra clearance and to account for dome imperfections" />
-            <TextBlock
-                Grid.Row="9"
-                Grid.Column="0"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Center"
-                Text="West to East"
-                ToolTip="{StaticResource WestToEast_Tooltip}" />
-            <CheckBox
-                Grid.Row="9"
-                Grid.Column="1"
-                Grid.ColumnSpan="2"
-                MinWidth="80"
-                Margin="5,5,0,0"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Center"
-                IsChecked="{Binding WestToEastSorting}"
-                ToolTip="{StaticResource WestToEast_Tooltip}" />
+            <GroupBox Margin="0,0,0,8">
+                <GroupBox.Header>
+                    <TextBlock FontSize="16" Text="Plate Solving" />
+                </GroupBox.Header>
+                <Grid Margin="5">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="OptionsCol0" />
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="OptionsCol1" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
 
-            <TextBlock
-                Grid.Row="10"
-                Grid.Column="0"
-                VerticalAlignment="Center"
-                Text="Start at Horizon"
-                ToolTip="{StaticResource StartAtHorizon_Tooltip}" />
-            <CheckBox
-                Grid.Row="10"
-                Grid.Column="1"
-                Grid.ColumnSpan="2"
-                MinWidth="80"
-                Margin="5,5,0,0"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Center"
-                IsChecked="{Binding StartAtHorizon}"
-                ToolTip="{StaticResource StartAtHorizon_Tooltip}" />
+                    <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Text="Log Commands" ToolTip="{StaticResource LogCommands_Tooltip}" />
+                    <CheckBox Grid.Row="0" Grid.Column="1" MinWidth="80" Margin="5,5,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" IsChecked="{Binding LogCommands}" ToolTip="{StaticResource LogCommands_Tooltip}" />
 
-            <TextBlock
-                Grid.Row="21"
-                Grid.Column="0"
-                VerticalAlignment="Center"
-                Text="End at Meridian Limit"
-                ToolTip="{StaticResource BalanceMeridianZone_Tooltip}" />
-            <CheckBox
-                Grid.Row="21"
-                Grid.Column="1"
-                Grid.ColumnSpan="2"
-                MinWidth="80"
-                Margin="5,5,0,0"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Center"
-                IsChecked="{Binding BalanceMeridianZone}"
-                ToolTip="{StaticResource BalanceMeridianZone_Tooltip}" />
-
-            <TextBlock
-                Grid.Row="11"
-                Grid.Column="0"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Center"
-                Text="Plate Solve Subframe"
-                ToolTip="{StaticResource PlateSolveSubframePercentage_Tooltip}" />
-            <ninactrl:UnitTextBox
-                Grid.Row="11"
-                Grid.Column="1"
-                MinWidth="80"
-                Margin="5,5,0,0"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Center"
-                ToolTip="{StaticResource PlateSolveSubframePercentage_Tooltip}"
-                Unit="%">
-                <Binding
-                    Converter="{StaticResource PercentageConverter}"
-                    ConverterParameter="1"
-                    Path="PlateSolveSubframePercentage"
-                    UpdateSourceTrigger="LostFocus">
-                    <Binding.ValidationRules>
-                        <rules:DoubleRangeRule>
-                            <rules:DoubleRangeRule.ValidRange>
-                                <rules:DoubleRangeChecker Maximum="100" Minimum="0.1" />
-                            </rules:DoubleRangeRule.ValidRange>
-                        </rules:DoubleRangeRule>
-                    </Binding.ValidationRules>
-                </Binding>
-            </ninactrl:UnitTextBox>
-            <TextBlock
-                Grid.Row="12"
-                Grid.Column="0"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Center"
-                Text="Alternate Direction"
-                ToolTip="{StaticResource AlternateDirectionsBetweenIterations_Tooltip}" />
-            <CheckBox
-                Grid.Row="12"
-                Grid.Column="1"
-                Grid.ColumnSpan="2"
-                MinWidth="80"
-                Margin="5,5,0,0"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Center"
-                IsChecked="{Binding AlternateDirectionsBetweenIterations}"
-                ToolTip="{StaticResource AlternateDirectionsBetweenIterations_Tooltip}" />
-
-            <TextBlock
-                Grid.Row="13"
-                Grid.Column="0"
-                VerticalAlignment="Center"
-                Text="Min Azimuth"
-                ToolTip="{StaticResource MinPointAzimuth_Tooltip}" />
-            <ninactrl:UnitTextBox
-                Grid.Row="13"
-                Grid.Column="1"
-                MinWidth="80"
-                Margin="5,5,0,0"
-                HorizontalAlignment="Left"
-                ToolTip="{StaticResource MinPointAzimuth_Tooltip}"
-                Unit="°">
-                <Binding Path="MinPointAzimuth" UpdateSourceTrigger="LostFocus">
-                    <Binding.ValidationRules>
-                        <rules:DoubleRangeRule>
-                            <rules:DoubleRangeRule.ValidRange>
-                                <rules:DoubleRangeChecker Maximum="360" Minimum="0" />
-                            </rules:DoubleRangeRule.ValidRange>
-                        </rules:DoubleRangeRule>
-                    </Binding.ValidationRules>
-                </Binding>
-            </ninactrl:UnitTextBox>
-
-            <TextBlock
-                Grid.Row="14"
-                Grid.Column="0"
-                VerticalAlignment="Center"
-                Text="Max Azimuth"
-                ToolTip="{StaticResource MaxPointAzimuth_Tooltip}" />
-            <ninactrl:UnitTextBox
-                Grid.Row="14"
-                Grid.Column="1"
-                MinWidth="80"
-                Margin="5,5,0,0"
-                HorizontalAlignment="Left"
-                ToolTip="{StaticResource MaxPointAzimuth_Tooltip}"
-                Unit="°">
-                <Binding Path="MaxPointAzimuth" UpdateSourceTrigger="LostFocus">
-                    <Binding.ValidationRules>
-                        <rules:DoubleRangeRule>
-                            <rules:DoubleRangeRule.ValidRange>
-                                <rules:DoubleRangeChecker Maximum="360" Minimum="0" />
-                            </rules:DoubleRangeRule.ValidRange>
-                        </rules:DoubleRangeRule>
-                    </Binding.ValidationRules>
-                </Binding>
-            </ninactrl:UnitTextBox>
-
-            <TextBlock
-                Grid.Row="15"
-                Grid.Column="0"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Center"
-                Text="Minimize Meridian Flips"
-                ToolTip="{StaticResource MinimizeMeridianFlips_Tooltip}" />
-            <CheckBox
-                Grid.Row="15"
-                Grid.Column="1"
-                MinWidth="80"
-                Margin="5,5,0,0"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Center"
-                IsChecked="{Binding MinimizeMeridianFlipsEnabled}"
-                ToolTip="{StaticResource MinimizeMeridianFlips_Tooltip}" />
-
-            <!--TextBlock
-                Grid.Row="16"
-                Grid.Column="0"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Center"
-                Text="Dec Jitter σ"
-                ToolTip="{StaticResource PlateSolveSubframePercentage_Tooltip}" />
-            <ninactrl:UnitTextBox
-                Grid.Row="16"
-                Grid.Column="1"
-                MinWidth="80"
-                Margin="5,5,0,0"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Center"
-                ToolTip="{StaticResource DecJitterSigma_Tooltip}"
-                Unit="°">
-                <Binding Path="DecJitterSigmaDegrees" UpdateSourceTrigger="LostFocus">
-                    <Binding.ValidationRules>
-                        <rules:DoubleRangeRule>
-                            <rules:DoubleRangeRule.ValidRange>
-                                <rules:DoubleRangeChecker Maximum="10.0" Minimum="0.0" />
-                            </rules:DoubleRangeRule.ValidRange>
-                        </rules:DoubleRangeRule>
-                    </Binding.ValidationRules>
-                </Binding>
-            </ninactrl:UnitTextBox-->
-            <TextBlock
-                Grid.Row="16"
-                Grid.Column="0"
-                VerticalAlignment="Center"
-                Text="Min Horizon Distance"
-                ToolTip="{StaticResource MinDistanceToHorizon_Tooltip}" />
-            <ninactrl:UnitTextBox
-                Grid.Row="16"
-                Grid.Column="1"
-                MinWidth="80"
-                Margin="5,5,0,0"
-                HorizontalAlignment="Left"
-                ToolTip="{StaticResource MinDistanceToHorizon_Tooltip}"
-                Unit="°">
-                <Binding Path="MinDistanceToHorizonDegrees" UpdateSourceTrigger="LostFocus">
-                    <Binding.ValidationRules>
-                        <rules:DoubleRangeRule>
-                            <rules:DoubleRangeRule.ValidRange>
-                                <rules:DoubleRangeChecker Maximum="90" Minimum="0" />
-                            </rules:DoubleRangeRule.ValidRange>
-                        </rules:DoubleRangeRule>
-                    </Binding.ValidationRules>
-                </Binding>
-            </ninactrl:UnitTextBox>
-
-            <TextBlock
-                 Grid.Row="17"
-                 Grid.Column="0"
-                 VerticalAlignment="Center"
-                 Text="Legacy DDM mount"
-                  ToolTip="" />
-            <CheckBox
-                 Grid.Row="17"
-                 Grid.Column="1"
-                 MinWidth="80"
-                 Margin="5,5,0,0"
-                 HorizontalAlignment="Left"
-                 VerticalAlignment="Center"
-                 IsChecked="{Binding IsLegacyDDM}" />
-            
-            <TextBlock
-                 Grid.Row="18"
-                 Grid.Column="0"
-                 VerticalAlignment="Center"
-                 Text="Let NINA control the Dome"
-                 ToolTip="" />
-            <CheckBox
-                 Grid.Row="18"
-                 Grid.Column="1"
-                 MinWidth="80"
-                 Margin="5,5,0,0"
-                 HorizontalAlignment="Left"
-                 VerticalAlignment="Center"
-                 IsChecked="{Binding DomeControlNINA}" />
-            
-            <TextBlock
-                Grid.Row="19"
-                Grid.Column="0"
-                VerticalAlignment="Center"
-                Text="POX Output Directory"
-                ToolTip="{StaticResource PoxOutputDirectory_Tooltip}" />
-
-            <Grid
-                Margin="5,5,0,0"
-                Grid.Row="19"
-                Grid.Column="1" 
-                HorizontalAlignment="Left"
-                VerticalAlignment="Center"
-            >
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition />
-                </Grid.ColumnDefinitions>
-                <TextBox
-                    Grid.Column="0"
-                    VerticalAlignment="Center"
-                    VerticalContentAlignment="Center">
-                    <TextBox.Text>
-                        <Binding Path="POXOutputDirectory" UpdateSourceTrigger="LostFocus">
+                    <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Text="Max Concurrency" ToolTip="{StaticResource MaxConcurrency_Tooltip}" />
+                    <ninactrl:UnitTextBox Grid.Row="1" Grid.Column="1" MinWidth="80" Margin="5,5,0,0" HorizontalAlignment="Left" ToolTip="{StaticResource MaxConcurrency_Tooltip}" Unit="plate solves">
+                        <Binding Converter="{StaticResource TM_ZeroToInfinityConverter}" Path="MaxConcurrency" UpdateSourceTrigger="LostFocus">
                             <Binding.ValidationRules>
-                                <rules:DirectoryExistsRule />
+                                <tmrules:PositiveIntegerOrInfiniteRule />
                             </Binding.ValidationRules>
                         </Binding>
-                    </TextBox.Text>
-                </TextBox>
+                    </ninactrl:UnitTextBox>
 
-                <Button
-                    Grid.Column="1"
-                    Width="40"
-                    Height="20"
-                    Margin="5,0,0,0"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Center"
-                    Command="{Binding ShowSelectPOXOutputDirectoryDialogCommand}">
-                    <Path
-                        Margin="12,10,12,0"
-                        Data="{StaticResource DotsSVG}"
-                        Fill="{StaticResource ButtonForegroundBrush}"
-                        Stretch="Uniform"
-                        UseLayoutRounding="True" />
-                </Button>
-            </Grid>
+                    <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Text="Allow Blind Solves" ToolTip="{StaticResource AllowBlindSolves_Tooltip}" />
+                    <CheckBox Grid.Row="2" Grid.Column="1" MinWidth="80" Margin="5,5,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" IsChecked="{Binding AllowBlindSolves}" ToolTip="{StaticResource AllowBlindSolves_Tooltip}" />
 
-            <TextBlock
-                Grid.Row="20"
-                Grid.Column="0"
-                VerticalAlignment="Center"
-                Text="MLPT Path Offset"
-                ToolTip="{StaticResource SiderealTrackPathOffsetMinutes_Tooltip}" />
-            <ninactrl:UnitTextBox
-                Grid.Row="20"
-                Grid.Column="1"
-                MinWidth="80"
-                Margin="5,5,0,0"
-                HorizontalAlignment="Left"
-                ToolTip="{StaticResource SiderealTrackPathOffsetMinutes_Tooltip}"
-                Unit="RA-minutes">
-                <Binding Path="SiderealTrackPathOffsetMinutes" UpdateSourceTrigger="LostFocus" />
-            </ninactrl:UnitTextBox>
-        </Grid>
+                    <TextBlock Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Text="Plate Solve Subframe" ToolTip="{StaticResource PlateSolveSubframePercentage_Tooltip}" />
+                    <ninactrl:UnitTextBox Grid.Row="3" Grid.Column="1" MinWidth="80" Margin="5,5,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" ToolTip="{StaticResource PlateSolveSubframePercentage_Tooltip}" Unit="%">
+                        <Binding Converter="{StaticResource PercentageConverter}" ConverterParameter="1" Path="PlateSolveSubframePercentage" UpdateSourceTrigger="LostFocus">
+                            <Binding.ValidationRules>
+                                <rules:DoubleRangeRule>
+                                    <rules:DoubleRangeRule.ValidRange>
+                                        <rules:DoubleRangeChecker Maximum="100" Minimum="0.1" />
+                                    </rules:DoubleRangeRule.ValidRange>
+                                </rules:DoubleRangeRule>
+                            </Binding.ValidationRules>
+                        </Binding>
+                    </ninactrl:UnitTextBox>
+                </Grid>
+            </GroupBox>
+
+            <GroupBox Margin="0,0,0,8">
+                <GroupBox.Header>
+                    <TextBlock FontSize="16" Text="Point Generation Limits" />
+                </GroupBox.Header>
+                <Grid Margin="5">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="OptionsCol0" />
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="OptionsCol1" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Text="Min Altitude" ToolTip="{StaticResource MinPointAltitude_Tooltip}" />
+                    <ninactrl:UnitTextBox Grid.Row="0" Grid.Column="1" MinWidth="80" Margin="5,5,0,0" HorizontalAlignment="Left" ToolTip="{StaticResource MinPointAltitude_Tooltip}" Unit="°">
+                        <Binding Path="MinPointAltitude" UpdateSourceTrigger="LostFocus">
+                            <Binding.ValidationRules>
+                                <rules:IntRangeRule>
+                                    <rules:IntRangeRule.ValidRange>
+                                        <rules:IntRangeChecker Maximum="90" Minimum="0" />
+                                    </rules:IntRangeRule.ValidRange>
+                                </rules:IntRangeRule>
+                            </Binding.ValidationRules>
+                        </Binding>
+                    </ninactrl:UnitTextBox>
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Text="Max Altitude" ToolTip="{StaticResource MaxPointAltitude_Tooltip}" />
+                    <ninactrl:UnitTextBox Grid.Row="1" Grid.Column="1" MinWidth="80" Margin="5,5,0,0" HorizontalAlignment="Left" ToolTip="{StaticResource MaxPointAltitude_Tooltip}" Unit="°">
+                        <Binding Path="MaxPointAltitude" UpdateSourceTrigger="LostFocus">
+                            <Binding.ValidationRules>
+                                <rules:IntRangeRule>
+                                    <rules:IntRangeRule.ValidRange>
+                                        <rules:IntRangeChecker Maximum="90" Minimum="0" />
+                                    </rules:IntRangeRule.ValidRange>
+                                </rules:IntRangeRule>
+                            </Binding.ValidationRules>
+                        </Binding>
+                    </ninactrl:UnitTextBox>
+
+                    <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Text="Min Azimuth" ToolTip="{StaticResource MinPointAzimuth_Tooltip}" />
+                    <ninactrl:UnitTextBox Grid.Row="2" Grid.Column="1" MinWidth="80" Margin="5,5,0,0" HorizontalAlignment="Left" ToolTip="{StaticResource MinPointAzimuth_Tooltip}" Unit="°">
+                        <Binding Path="MinPointAzimuth" UpdateSourceTrigger="LostFocus">
+                            <Binding.ValidationRules>
+                                <rules:DoubleRangeRule>
+                                    <rules:DoubleRangeRule.ValidRange>
+                                        <rules:DoubleRangeChecker Maximum="360" Minimum="0" />
+                                    </rules:DoubleRangeRule.ValidRange>
+                                </rules:DoubleRangeRule>
+                            </Binding.ValidationRules>
+                        </Binding>
+                    </ninactrl:UnitTextBox>
+
+                    <TextBlock Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Text="Max Azimuth" ToolTip="{StaticResource MaxPointAzimuth_Tooltip}" />
+                    <ninactrl:UnitTextBox Grid.Row="3" Grid.Column="1" MinWidth="80" Margin="5,5,0,0" HorizontalAlignment="Left" ToolTip="{StaticResource MaxPointAzimuth_Tooltip}" Unit="°">
+                        <Binding Path="MaxPointAzimuth" UpdateSourceTrigger="LostFocus">
+                            <Binding.ValidationRules>
+                                <rules:DoubleRangeRule>
+                                    <rules:DoubleRangeRule.ValidRange>
+                                        <rules:DoubleRangeChecker Maximum="360" Minimum="0" />
+                                    </rules:DoubleRangeRule.ValidRange>
+                                </rules:DoubleRangeRule>
+                            </Binding.ValidationRules>
+                        </Binding>
+                    </ninactrl:UnitTextBox>
+
+                    <TextBlock Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" Text="Min Horizon Distance" ToolTip="{StaticResource MinDistanceToHorizon_Tooltip}" />
+                    <ninactrl:UnitTextBox Grid.Row="4" Grid.Column="1" MinWidth="80" Margin="5,5,0,0" HorizontalAlignment="Left" ToolTip="{StaticResource MinDistanceToHorizon_Tooltip}" Unit="°">
+                        <Binding Path="MinDistanceToHorizonDegrees" UpdateSourceTrigger="LostFocus">
+                            <Binding.ValidationRules>
+                                <rules:DoubleRangeRule>
+                                    <rules:DoubleRangeRule.ValidRange>
+                                        <rules:DoubleRangeChecker Maximum="90" Minimum="0" />
+                                    </rules:DoubleRangeRule.ValidRange>
+                                </rules:DoubleRangeRule>
+                            </Binding.ValidationRules>
+                        </Binding>
+                    </ninactrl:UnitTextBox>
+
+                    <TextBlock Grid.Row="5" Grid.Column="0" VerticalAlignment="Center" Text="Show Removed Points" ToolTip="{StaticResource ShowRemovedPoints_Tooltip}" />
+                    <CheckBox Grid.Row="5" Grid.Column="1" MinWidth="80" Margin="5,5,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" IsChecked="{Binding ShowRemovedPoints}" ToolTip="{StaticResource ShowRemovedPoints_Tooltip}" />
+                </Grid>
+            </GroupBox>
+
+            <GroupBox Margin="0,0,0,8">
+                <GroupBox.Header>
+                    <TextBlock FontSize="16" Text="AutoGrid Anchoring" />
+                </GroupBox.Header>
+                <Grid Margin="5">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="OptionsCol0" />
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="OptionsCol1" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,0,0,4" Opacity="0.85" Text="Use one anchor strategy at a time. Enabling one mode turns the other off." TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Text="Start at Horizon" ToolTip="{StaticResource StartAtHorizon_Tooltip}" />
+                    <CheckBox Grid.Row="1" Grid.Column="1" MinWidth="80" Margin="5,5,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" IsChecked="{Binding StartAtHorizon}" ToolTip="{StaticResource StartAtHorizon_Tooltip}" />
+
+                    <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Text="End at Meridian Limit" ToolTip="{StaticResource BalanceMeridianZone_Tooltip}" />
+                    <CheckBox Grid.Row="2" Grid.Column="1" MinWidth="80" Margin="5,5,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" IsChecked="{Binding BalanceMeridianZone}" ToolTip="{StaticResource BalanceMeridianZone_Tooltip}" />
+                </Grid>
+            </GroupBox>
+
+            <GroupBox Margin="0,0,0,8">
+                <GroupBox.Header>
+                    <TextBlock FontSize="16" Text="Traversal &amp; Iteration" />
+                </GroupBox.Header>
+                <Grid Margin="5">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="OptionsCol0" />
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="OptionsCol1" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Text="West to East" ToolTip="{StaticResource WestToEast_Tooltip}" />
+                    <CheckBox Grid.Row="0" Grid.Column="1" MinWidth="80" Margin="5,5,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" IsChecked="{Binding WestToEastSorting}" ToolTip="{StaticResource WestToEast_Tooltip}" />
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Text="Alternate Direction" ToolTip="{StaticResource AlternateDirectionsBetweenIterations_Tooltip}" />
+                    <CheckBox Grid.Row="1" Grid.Column="1" MinWidth="80" Margin="5,5,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" IsChecked="{Binding AlternateDirectionsBetweenIterations}" ToolTip="{StaticResource AlternateDirectionsBetweenIterations_Tooltip}" />
+
+                    <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Text="Minimize Meridian Flips" ToolTip="{StaticResource MinimizeMeridianFlips_Tooltip}" />
+                    <CheckBox Grid.Row="2" Grid.Column="1" MinWidth="80" Margin="5,5,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" IsChecked="{Binding MinimizeMeridianFlipsEnabled}" ToolTip="{StaticResource MinimizeMeridianFlips_Tooltip}" />
+                </Grid>
+            </GroupBox>
+
+            <GroupBox Margin="0,0,0,8">
+                <GroupBox.Header>
+                    <TextBlock FontSize="16" Text="Dome" />
+                </GroupBox.Header>
+                <Grid Margin="5">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="OptionsCol0" />
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="OptionsCol1" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Text="Optimize Dome" ToolTip="{StaticResource MinimizeDomeMovement_Tooltip}" />
+                    <CheckBox Grid.Row="0" Grid.Column="1" MinWidth="80" Margin="5,5,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" IsChecked="{Binding MinimizeDomeMovementEnabled}" ToolTip="{StaticResource MinimizeDomeMovement_Tooltip}" />
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Text="Dome Shutter Width" ToolTip="{StaticResource DomeShutterWidth_Tooltip}" />
+                    <ninactrl:UnitTextBox Grid.Row="1" Grid.Column="1" MinWidth="80" Margin="5,5,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" ToolTip="{StaticResource DomeShutterWidth_Tooltip}" Unit="mm">
+                        <Binding Converter="{StaticResource TM_ZeroToDisabledConverter}" Path="DomeShutterWidth_mm" UpdateSourceTrigger="LostFocus">
+                            <Binding.ValidationRules>
+                                <rules:GreaterZeroRule />
+                            </Binding.ValidationRules>
+                        </Binding>
+                    </ninactrl:UnitTextBox>
+                    <TextBlock Grid.Row="1" Grid.Column="2" Margin="8,5,0,0" VerticalAlignment="Center" Text="Tip: set slightly below actual width for extra clearance." TextWrapping="Wrap" />
+
+                    <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Text="Let NINA control the Dome" ToolTip="{StaticResource DomeControlNINA_Tooltip}" />
+                    <CheckBox Grid.Row="2" Grid.Column="1" MinWidth="80" Margin="5,5,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" IsChecked="{Binding DomeControlNINA}" ToolTip="{StaticResource DomeControlNINA_Tooltip}" />
+                </Grid>
+            </GroupBox>
+
+            <GroupBox Margin="0,0,0,8">
+                <GroupBox.Header>
+                    <TextBlock FontSize="16" Text="Mount &amp; Output" />
+                </GroupBox.Header>
+                <Grid Margin="5">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="OptionsCol0" />
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="OptionsCol1" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Text="Legacy Autoslew" ToolTip="{StaticResource LegacyDDM_Tooltip}" />
+                    <CheckBox Grid.Row="0" Grid.Column="1" MinWidth="80" Margin="5,5,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" IsChecked="{Binding IsLegacyDDM}" ToolTip="{StaticResource LegacyDDM_Tooltip}" />
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Text="MLPT Path Offset" ToolTip="{StaticResource MLTPPathOffset_Tooltip}" />
+                    <ninactrl:UnitTextBox Grid.Row="1" Grid.Column="1" MinWidth="80" Margin="5,5,0,0" HorizontalAlignment="Left" ToolTip="{StaticResource MLTPPathOffset_Tooltip}" Unit="RA-minutes">
+                        <Binding Path="SiderealTrackPathOffsetMinutes" UpdateSourceTrigger="LostFocus" />
+                    </ninactrl:UnitTextBox>
+
+                    <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Text="POX Output Directory" ToolTip="{StaticResource PoxOutputDirectory_Tooltip}" />
+                    <Grid Grid.Row="2" Grid.Column="1" Margin="5,5,0,0" HorizontalAlignment="Left" VerticalAlignment="Center">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition />
+                        </Grid.ColumnDefinitions>
+                        <TextBox Grid.Column="0" VerticalAlignment="Center" VerticalContentAlignment="Center">
+                            <TextBox.Text>
+                                <Binding Path="POXOutputDirectory" UpdateSourceTrigger="LostFocus">
+                                    <Binding.ValidationRules>
+                                        <rules:DirectoryExistsRule />
+                                    </Binding.ValidationRules>
+                                </Binding>
+                            </TextBox.Text>
+                        </TextBox>
+                        <Button Grid.Column="1" Width="40" Height="20" Margin="5,0,0,0" HorizontalAlignment="Center" VerticalAlignment="Center" Command="{Binding ShowSelectPOXOutputDirectoryDialogCommand}">
+                            <Path Margin="12,10,12,0" Data="{StaticResource DotsSVG}" Fill="{StaticResource ButtonForegroundBrush}" Stretch="Uniform" UseLayoutRounding="True" />
+                        </Button>
+                    </Grid>
+                </Grid>
+            </GroupBox>
+        </StackPanel>
     </DataTemplate>
 </ResourceDictionary>

--- a/NINA.Photon.Plugin.ASA/Resources/OptionsDataTemplates.xaml
+++ b/NINA.Photon.Plugin.ASA/Resources/OptionsDataTemplates.xaml
@@ -80,6 +80,7 @@
                 <TextBlock x:Key="MinPointAzimuth_Tooltip" Text="The minimum azimuth allowed for point generation. This is helpful for providing clearance during the point where meridian flips occur" />
                 <TextBlock x:Key="MaxPointAzimuth_Tooltip" Text="The maximum azimuth allowed for point generation. This is helpful for providing clearance during the point where meridian flips occur" />
                 <TextBlock x:Key="MinDistanceToHorizon_Tooltip" Text="Minimum clearance above the custom horizon required for generated points" />
+                <TextBlock x:Key="StartAtHorizon_Tooltip" Text="When enabled for AutoGrid, the first generated point per side (east/west) in each band starts from the lowest valid horizon-adjacent point" />
                 <TextBlock x:Key="ShowRemovedPoints_Tooltip" Text="Whether to show points that were rejected for being outside of the altitude bounds or below the defined horizon" />
                 <TextBlock x:Key="DomeShutterWidth_Tooltip" Text="The width of the dome shutter, in mm. If set, this is used to determine if the scope is pointing out of the shutter instead of the Threshold setting from Dome Options" />
                 <TextBlock x:Key="MinimizeDomeMovement_Tooltip" Text="If enabled, points will be ordered based on the calculated dome azimuth. The left boundary of the dome opening is used for E-&gt;W sorting, and the right boundary for W-&gt;E" />
@@ -274,6 +275,23 @@
                 VerticalAlignment="Center"
                 IsChecked="{Binding WestToEastSorting}"
                 ToolTip="{StaticResource WestToEast_Tooltip}" />
+
+            <TextBlock
+                Grid.Row="10"
+                Grid.Column="0"
+                VerticalAlignment="Center"
+                Text="Start at Horizon"
+                ToolTip="{StaticResource StartAtHorizon_Tooltip}" />
+            <CheckBox
+                Grid.Row="10"
+                Grid.Column="1"
+                Grid.ColumnSpan="2"
+                MinWidth="80"
+                Margin="5,5,0,0"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                IsChecked="{Binding StartAtHorizon}"
+                ToolTip="{StaticResource StartAtHorizon_Tooltip}" />
 
             <TextBlock
                 Grid.Row="11"

--- a/NINA.Photon.Plugin.ASA/View/MountModelBuilderView.xaml
+++ b/NINA.Photon.Plugin.ASA/View/MountModelBuilderView.xaml
@@ -227,18 +227,30 @@
                             </ComboBox.ItemTemplate>
                         </ComboBox>
 
-                                                <TextBlock
+                        <TextBlock
                                                         Grid.Row="2" Grid.Column="0"
-                                                        HorizontalAlignment="Left"
-                                                        VerticalAlignment="Center"
-                                                        Text="Show path"
-                                                        ToolTip="Connect generated points using a dotted preview line" />
-                                                <CheckBox
+                              HorizontalAlignment="Left"
+                              VerticalAlignment="Center"
+                              Text="Min horizon distance"
+                              ToolTip="Minimum clearance above horizon for generated points" />
+                        <ninactrl:UnitTextBox
                                                         Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2"
-                                                        Margin="10,5,0,0"
-                                                        HorizontalAlignment="Left"
-                                                        VerticalAlignment="Center"
-                                                        IsChecked="{Binding ShowDisplayPath}" />
+                              MinWidth="80"
+                              Margin="10,5,0,0"
+                              HorizontalAlignment="Left"
+                              VerticalAlignment="Center"
+                              Unit="°"
+                              ToolTip="Minimum clearance above horizon for generated points">
+                            <Binding Path="MinDistanceToHorizonDegrees" UpdateSourceTrigger="LostFocus">
+                                <Binding.ValidationRules>
+                                    <rules:DoubleRangeRule>
+                                        <rules:DoubleRangeRule.ValidRange>
+                                            <rules:DoubleRangeChecker Maximum="90" Minimum="0" />
+                                        </rules:DoubleRangeRule.ValidRange>
+                                    </rules:DoubleRangeRule>
+                                </Binding.ValidationRules>
+                            </Binding>
+                        </ninactrl:UnitTextBox>
 
                         <TextBlock
                                                         Grid.Row="3" Grid.Column="0"
@@ -1246,26 +1258,14 @@
                             Grid.Row="5" Grid.Column="0"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
-                            Text="Min horizon distance"
-                            ToolTip="Minimum clearance above horizon for generated points" />
-                        <ninactrl:UnitTextBox
+                            Text="Show path"
+                            ToolTip="Connect generated points using a dotted preview line" />
+                        <CheckBox
                             Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="2"
-                            MinWidth="80"
                             Margin="10,5,0,0"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
-                            Unit="°"
-                            ToolTip="Minimum clearance above horizon for generated points">
-                            <Binding Path="MinDistanceToHorizonDegrees" UpdateSourceTrigger="LostFocus">
-                                <Binding.ValidationRules>
-                                    <rules:DoubleRangeRule>
-                                        <rules:DoubleRangeRule.ValidRange>
-                                            <rules:DoubleRangeChecker Maximum="90" Minimum="0" />
-                                        </rules:DoubleRangeRule.ValidRange>
-                                    </rules:DoubleRangeRule>
-                                </Binding.ValidationRules>
-                            </Binding>
-                        </ninactrl:UnitTextBox>
+                            IsChecked="{Binding ShowDisplayPath}" />
 
                                 <TextBlock
                             Grid.Row="6" Grid.Column="0"

--- a/NINA.Photon.Plugin.ASA/View/MountModelBuilderView.xaml
+++ b/NINA.Photon.Plugin.ASA/View/MountModelBuilderView.xaml
@@ -281,6 +281,20 @@
                               IsChecked="{Binding StartAtHorizon}" />
 
                         <TextBlock
+                                              Grid.Row="7" Grid.Column="0"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            Text="End at meridian limit"
+                            ToolTip="For AutoGrid, anchor each band so the last point on each side is as close as possible to meridian limit" />
+                        <CheckBox
+                                              Grid.Row="7" Grid.Column="1" Grid.ColumnSpan="2"
+                            Margin="10,5,0,0"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            ToolTip="For AutoGrid, anchor each band so the last point on each side is as close as possible to meridian limit"
+                            IsChecked="{Binding BalanceMeridianZone}" />
+
+                        <TextBlock
                                                         Grid.Row="4" Grid.Column="0"
                               HorizontalAlignment="Left"
                               VerticalAlignment="Center"

--- a/NINA.Photon.Plugin.ASA/View/MountModelBuilderView.xaml
+++ b/NINA.Photon.Plugin.ASA/View/MountModelBuilderView.xaml
@@ -267,6 +267,20 @@
                         </ninactrl:UnitTextBox>
 
                         <TextBlock
+                                                        Grid.Row="6" Grid.Column="0"
+                              HorizontalAlignment="Left"
+                              VerticalAlignment="Center"
+                              Text="Start at horizon"
+                              ToolTip="Start each side (east/west) from the lowest valid point per band" />
+                        <CheckBox
+                                                        Grid.Row="6" Grid.Column="1" Grid.ColumnSpan="2"
+                              Margin="10,5,0,0"
+                              HorizontalAlignment="Left"
+                              VerticalAlignment="Center"
+                              ToolTip="Start each side (east/west) from the lowest valid point per band"
+                              IsChecked="{Binding StartAtHorizon}" />
+
+                        <TextBlock
                                                         Grid.Row="4" Grid.Column="0"
                               HorizontalAlignment="Left"
                               VerticalAlignment="Center"

--- a/NINA.Photon.Plugin.ASA/ViewModels/MountModelBuilderVM.cs
+++ b/NINA.Photon.Plugin.ASA/ViewModels/MountModelBuilderVM.cs
@@ -764,6 +764,11 @@ namespace NINA.Photon.Plugin.ASA.ViewModels
                 RaisePropertyChanged(nameof(StartAtHorizon));
             }
 
+            if (e.PropertyName == nameof(modelBuilderOptions.BalanceMeridianZone))
+            {
+                RaisePropertyChanged(nameof(BalanceMeridianZone));
+            }
+
             if (e.PropertyName == nameof(modelBuilderOptions.SiderealTrackPathOffsetMinutes))
             {
                 RaisePropertyChanged(nameof(SiderealTrackPathOffsetMinutes));
@@ -2104,6 +2109,19 @@ namespace NINA.Photon.Plugin.ASA.ViewModels
                 if (this.modelBuilderOptions.StartAtHorizon != value)
                 {
                     this.modelBuilderOptions.StartAtHorizon = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public bool BalanceMeridianZone
+        {
+            get => this.modelBuilderOptions.BalanceMeridianZone;
+            set
+            {
+                if (this.modelBuilderOptions.BalanceMeridianZone != value)
+                {
+                    this.modelBuilderOptions.BalanceMeridianZone = value;
                     RaisePropertyChanged();
                 }
             }

--- a/NINA.Photon.Plugin.ASA/ViewModels/MountModelBuilderVM.cs
+++ b/NINA.Photon.Plugin.ASA/ViewModels/MountModelBuilderVM.cs
@@ -759,6 +759,11 @@ namespace NINA.Photon.Plugin.ASA.ViewModels
                 RaisePropertyChanged(nameof(MinDistanceToHorizonDegrees));
             }
 
+            if (e.PropertyName == nameof(modelBuilderOptions.StartAtHorizon))
+            {
+                RaisePropertyChanged(nameof(StartAtHorizon));
+            }
+
             if (e.PropertyName == nameof(modelBuilderOptions.SiderealTrackPathOffsetMinutes))
             {
                 RaisePropertyChanged(nameof(SiderealTrackPathOffsetMinutes));
@@ -2086,6 +2091,19 @@ namespace NINA.Photon.Plugin.ASA.ViewModels
                 if (this.modelBuilderOptions.AutoGridPathOrderingMode != value)
                 {
                     this.modelBuilderOptions.AutoGridPathOrderingMode = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public bool StartAtHorizon
+        {
+            get => this.modelBuilderOptions.StartAtHorizon;
+            set
+            {
+                if (this.modelBuilderOptions.StartAtHorizon != value)
+                {
+                    this.modelBuilderOptions.StartAtHorizon = value;
                     RaisePropertyChanged();
                 }
             }


### PR DESCRIPTION
## 3.8.2.5 (2026-02-22)

### AutoGrid Anchoring

- Added **Start at horizon** as a shared option (global + builder) for AutoGrid.
- Added **End at meridian limit** as a shared option (global + builder) for AutoGrid.
- Made both anchor modes mutually exclusive so enabling one automatically disables the other.
- Improved AutoGrid anchoring logic to evaluate each side (east/west) per band independently.
- Enabled **End at meridian limit** behavior for both AutoGrid input modes:
  - **Desired points** mode
  - **Fixed spacing** mode
- Added a fixed **1° safety margin** from the meridian limit target to reduce unexpected flip-risk edge cases.


### Model Build Safety Guard

- Added a pre-build guard for non-MLPT model builds that checks Autoslew pointing corrections (`GetCorrections`).
  - If corrections are non-zero (indicating config/model was not cleared), the user is prompted with a Yes/No confirmation before continuing.
  - Proceeding explicitly warns that the new model will be built on top of an existing model (potentially useful for PA/collimation with few points, but not recommended for full-sky models).

### Options UI / Usability

- Reorganized plugin options into clearer categories in the main options template.
- Added/updated descriptions and tooltips for ambiguous settings (including Legacy DDM and dome-control options).
- Moved **Show path** into **Chart options** in the model builder UI.
- Moved **Min horizon distance** into **AutoGrid options** in the model builder UI.


